### PR TITLE
Fix for new service IDs

### DIFF
--- a/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
+++ b/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
@@ -9,6 +9,11 @@ namespace OpenLDBWS
 {
     public partial class BaseServiceItem
     {
+        // new service ID format: 0000000XXXXXXXX, where 0 is any numeric char
+        // and X is any alpha char or an underscore. So far, all service IDs
+        // appear to end in at least one underscore, but I am uncertain if this
+        // is always the case
+
         // underscores are already URL-safe, so we do not need to encode them
         // (and in fact WebUtility.UrlEncode will not change this string)
         public string ServiceIdPercentEncoded => serviceIDField;
@@ -23,13 +28,13 @@ namespace OpenLDBWS
         {
             // because we have 128 bits to use in the GUID (and only ~56 bits
             // from the service ID), we can afford to encode the 7 numeric
-            // characters directly and the 7 alpha characters as ASCII instead
+            // characters directly and the 8 alpha characters as ASCII instead
             // of finding a more efficient solution, and zero-pad the centre
             string num = serviceID.Substring(0, 7); // digits
-            string str = serviceID.Substring(7, 7); // letters
+            string str = serviceID.Substring(7, 8); // letters
             byte[] bytes = System.Text.Encoding.UTF8.GetBytes(str);
             string hexString = Convert.ToHexString(bytes);
-            string guidString = num + "00000000000" + hexString.Substring(0, 14);
+            string guidString = num + "000000000" + hexString.Substring(0, 16);
             return new Guid(guidString);
         }
 
@@ -38,10 +43,10 @@ namespace OpenLDBWS
             // reverse of ToGuid above
             string guidString = serviceGuid.ToString("N");
             string num = guidString.Substring(0, 7); // get digits
-            string hexString = guidString.Substring(18, 14); // get letters
+            string hexString = guidString.Substring(16, 16); // get letters
             byte[] bytes = Convert.FromHexString(hexString);
             string str = System.Text.Encoding.UTF8.GetString(bytes);
-            return num + str + "_";
+            return num + str;
         }
     }
 }

--- a/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
+++ b/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
@@ -3,7 +3,6 @@
 using Microsoft.AspNetCore.WebUtilities;
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 
 namespace OpenLDBWS
 {
@@ -20,9 +19,14 @@ namespace OpenLDBWS
 
         public Guid ServiceIdGuid => ToGuid(serviceIDField);
 
-        // as above
+        // note that while ServiceID is already URL-safe, the underscore char
+        // is not valid base64, so any inputs that previously assumed b64 input
+        // may break. As such, we will encode the string to be b64-safe as well
+        // as URL-safe
         [SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "Not a URL")]
-        public string ServiceIdUrlSafe => serviceIDField;
+        public string ServiceIdUrlSafe => WebEncoders.Base64UrlEncode(
+            System.Text.Encoding.UTF8.GetBytes(serviceIDField)
+        );
 
         public static Guid ToGuid(string serviceID)
         {

--- a/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
+++ b/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
@@ -9,11 +9,39 @@ namespace OpenLDBWS
 {
     public partial class BaseServiceItem
     {
-        public string ServiceIdPercentEncoded => WebUtility.UrlEncode(serviceIDField);
+        // underscores are already URL-safe, so we do not need to encode them
+        // (and in fact WebUtility.UrlEncode will not change this string)
+        public string ServiceIdPercentEncoded => serviceIDField;
 
-        public Guid ServiceIdGuid => new Guid(Convert.FromBase64String(serviceIDField));
+        public Guid ServiceIdGuid => ToGuid(serviceIDField);
 
+        // as above
         [SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "Not a URL")]
-        public string ServiceIdUrlSafe => WebEncoders.Base64UrlEncode(Convert.FromBase64String(serviceIDField));
+        public string ServiceIdUrlSafe => serviceIDField;
+
+        public static Guid ToGuid(string serviceID)
+        {
+            // because we have 128 bits to use in the GUID (and only ~56 bits
+            // from the service ID), we can afford to encode the 7 numeric
+            // characters directly and the 7 alpha characters as ASCII instead
+            // of finding a more efficient solution, and zero-pad the centre
+            string num = serviceID.Substring(0, 7); // digits
+            string str = serviceID.Substring(7, 7); // letters
+            byte[] bytes = System.Text.Encoding.UTF8.GetBytes(str);
+            string hexString = Convert.ToHexString(bytes);
+            string guidString = num + "00000000000" + hexString.Substring(0, 14);
+            return new Guid(guidString);
+        }
+
+        public static string FromGuid(Guid serviceGuid)
+        {
+            // reverse of ToGuid above
+            string guidString = serviceGuid.ToString("N");
+            string num = guidString.Substring(0, 7); // get digits
+            string hexString = guidString.Substring(18, 14); // get letters
+            byte[] bytes = Convert.FromHexString(hexString);
+            string str = System.Text.Encoding.UTF8.GetString(bytes);
+            return num + str + "_";
+        }
     }
 }

--- a/Huxley2/Services/ServiceDetailsService.cs
+++ b/Huxley2/Services/ServiceDetailsService.cs
@@ -76,9 +76,9 @@ namespace Huxley2.Services
             }
 
             // handle new-format version
-            // structure: 0000000XXXXXX_, where 0 is any numeric char and X is
-            //            any alpha char
-            if (request.ServiceId.Length == 15 && request.ServiceId.EndsWith("_"))
+            // structure: 0000000XXXXXXX, where 0 is any numeric char and X is
+            //            any alpha char or an underscore
+            if (request.ServiceId.Length == 15)
             {
                 _logger.LogInformation($"Calling service details SOAP endpoint for {request.ServiceId}");
                 var s = await _soapClient.GetServiceDetailsAsync(new GetServiceDetailsRequest

--- a/Huxley2Tests/OpenLDBWS/BaseServiceItemTests.cs
+++ b/Huxley2Tests/OpenLDBWS/BaseServiceItemTests.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.WebUtilities;
 using OpenLDBWS;
 using System;
 using System.Net;
+using System.Text;
 using Xunit;
 
 namespace Huxley2Tests.OpenLDBWS
@@ -13,21 +14,28 @@ namespace Huxley2Tests.OpenLDBWS
         [Fact]
         public void ServiceItemIdIsPercentEncoded()
         {
+            // because the new-format codes don't need percent encoding, this
+            // operation should do nothing, for backwards compatibility
+            var code = "4613377ABRYSTH_";
             var serviceItem = new BaseServiceItem
             {
-                serviceID = Convert.ToBase64String(Guid.NewGuid().ToByteArray())
+                serviceID = code
             };
             var expected = WebUtility.UrlEncode(serviceItem.serviceID);
+            Assert.Equal(code, serviceItem.ServiceIdPercentEncoded);
             Assert.Equal(expected, serviceItem.ServiceIdPercentEncoded);
         }
 
         [Fact]
         public void ServiceItemIdIsGuidEncoded()
         {
-            var expected = Guid.NewGuid();
+            // we now use a custom encoding into a GUID, because the new-format
+            // codes do not neatly convert.
+            var code = "4611018PADTON__";
+            var expected = BaseServiceItem.ToGuid(code);
             var serviceItem = new BaseServiceItem
             {
-                serviceID = Convert.ToBase64String(expected.ToByteArray())
+                serviceID = code
             };
             Assert.Equal(expected, serviceItem.ServiceIdGuid);
         }
@@ -35,14 +43,15 @@ namespace Huxley2Tests.OpenLDBWS
         [Fact]
         public void ServiceItemIdIsUrlSafeEncoded()
         {
+            var code = "4629324MNCRPIC_";
             var serviceItem = new BaseServiceItem
             {
-                serviceID = Convert.ToBase64String(Guid.NewGuid().ToByteArray())
+                serviceID = code
             };
-            var expected = WebEncoders.Base64UrlEncode(Convert.FromBase64String(serviceItem.serviceID));
+            var expected = WebEncoders.Base64UrlEncode(
+                System.Text.Encoding.UTF8.GetBytes(code)
+            );
             Assert.Equal(expected, serviceItem.ServiceIdUrlSafe);
         }
-
-
     }
 }


### PR DESCRIPTION
Apparent fix for #13

I do not have a staff token, so cannot test whether there are separate problems there, but this patch allows for GUID encoding of the new IDs and correct parsing