### PR TITLE
chore: boxhill -> box hill

### DIFF
--- a/station_codes.csv
+++ b/station_codes.csv
@@ -342,7 +342,7 @@
 "Bow Street","BOW"
 "Bowes Park","BOP"
 "Bowling","BWG"
-"Boxhill & Westhumble","BXW"
+"Box Hill & Westhumble","BXW"
 "Bracknell","BCE"
 "Bradford Forster Square","BDQ"
 "Bradford Interchange","BDI"


### PR DESCRIPTION
Box Hill & Westhumble's name has been standardised in this form since 2006

Source: https://www.networkrailmediacentre.co.uk/news/gbp-1m-upgrade-at-box-hill-westhumble-station