### PR TITLE
chore: dunfermline town -> dunfermline city

### DIFF
--- a/station_codes.csv
+++ b/station_codes.csv
@@ -836,7 +836,7 @@
 "Duncraig","DCG"
 "Dundee","DEE"
 "Dunfermline Queen Margaret","DFL"
-"Dunfermline Town","DFE"
+"Dunfermline City","DFE"
 "Dunkeld & Birnam","DKD"
 "Dunlop","DNL"
 "Dunoon (Bus)","DUO"


### PR DESCRIPTION
This station was renamed in October 2022 when Dunfermline gained city status