### PR TITLE
add meta tags for a11y improvements

### DIFF
--- a/Huxley2/Pages/Index.cshtml
+++ b/Huxley2/Pages/Index.cshtml
@@ -8,6 +8,8 @@
 <html lang="en">
 
 <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="A cross-platform JSON proxy for the GB railway Live Departure Boards SOAP API">
     <title>Huxley 2 - Community Edition</title>
     <link href="~/lib/twitter-bootstrap/css/bootstrap.min.css" rel="stylesheet">
 </head>


### PR DESCRIPTION
the meta description tag helps screen readers know what the page is about, and the meta viewport tag makes the content play a bit nicer on mobile, mostly so font sizes are legible.

current site on firefox, scaled to mobile width
![Screenshot from 2024-09-07 20-13-15](https://github.com/user-attachments/assets/569929f4-55a8-45da-aa07-e0989c4d150d)

this commit, scaled to mobile width
![Screenshot from 2024-09-07 20-13-07](https://github.com/user-attachments/assets/f74fb32d-e1ee-41c4-b4e2-88b2aebb3c45)
