### PR TITLE
slim down the final container image

### DIFF
--- a/Huxley2/Dockerfile
+++ b/Huxley2/Dockerfile
@@ -3,14 +3,20 @@ WORKDIR /app
 
 # Copy csproj and restore as distinct layers
 COPY *.csproj ./
-RUN dotnet restore
+RUN dotnet restore --runtime alpine-x64
 
 # Copy everything else and build
 COPY . ./
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -c Release -o out \
+  --no-restore \
+  --runtime alpine-x64 \
+  --self-contained true \
+  /p:PublishTrimmed=true \
+  /p:PublishSingleFile=true
+
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:6.0
+FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine
 WORKDIR /app
 COPY --from=build-env /app/out .
-ENTRYPOINT ["dotnet", "Huxley2.dll"]
+ENTRYPOINT ["./Huxley2"]


### PR DESCRIPTION
we can update the multi-stage build to output a final compile target that has the runtime, as well as run it in a base image that only includes the runtime dependencies. This takes the final image from 232MB to 79MB. 

```
docker images | grep -i hux
huxley-runtime                                                       latest                                     327af2243b68   7 minutes ago    77.8MB
huxley                                                               latest                                     3b93cf09e9c3   19 hours ago     232MB
```